### PR TITLE
Changed the values of the hashed object!

### DIFF
--- a/lib/verb.js
+++ b/lib/verb.js
@@ -12,34 +12,33 @@
 */
 
 module.exports = function(cb) {
-
   var verb_tenses_keys = {
-    "infinitive"           : 0,
-    "1st singular present" : 1,
-    "2nd singular present" : 2,
-    "3rd singular present" : 3,
-    "present plural"       : 4,
-    "present participle"   : 5,
-    "1st singular past"    : 6,
-    "2nd singular past"    : 7,
-    "3rd singular past"    : 8,
-    "past plural"          : 9,
-    "past"                 : 10,
-    "past participle"      : 11
+    infinitive: 0,
+    '1st singular present': 1,
+    '2nd singular present': 2,
+    '3rd singular present': 3,
+    'present plural': 4,
+    'present participle': 5,
+    '1st singular past': 6,
+    '2nd singular past': 7,
+    '3rd singular past': 8,
+    'past plural': 9,
+    past: 10,
+    'past participle': 11
   }
 
   var verb_tenses_aliases = {
-    "inf"     : "infinitive",
-    "1sgpres" : "1st singular present",
-    "2sgpres" : "2nd singular present",
-    "3sgpres" : "3rd singular present",
-    "pl"      : "present plural",
-    "prog"    : "present participle",
-    "1sgpast" : "1st singular past",
-    "2sgpast" : "2nd singular past",
-    "3sgpast" : "3rd singular past",
-    "pastpl"  : "past plural",
-    "ppart"   : "past participle"
+    inf: 'infinitive',
+    '1sgpres': '1st singular present',
+    '2sgpres': '2nd singular present',
+    '3sgpres': '3rd singular present',
+    pl: 'present plural',
+    prog: 'present participle',
+    '1sgpast': '1st singular past',
+    '2sgpast': '2nd singular past',
+    '3sgpast': '3rd singular past',
+    pastpl: 'past plural',
+    ppart: 'past participle'
   }
 
   /*
@@ -54,42 +53,47 @@ module.exports = function(cb) {
 
   var verbTenses = {}
 
-  var fs    = require("fs");
-  var path  = require("path");
-  var readline = require('readline');
+  var fs = require('fs')
+  var path = require('path')
+  var readline = require('readline')
 
-  var fpath     = path.join(path.dirname(__dirname), "lib", "verb.txt")
-  var stream    = require('stream');
-  var instream  = fs.createReadStream(fpath);
-  var outstream = new stream;
-  var rl = readline.createInterface(instream, outstream);
+  var fpath = path.join(path.dirname(__dirname), 'lib', 'verb.txt')
+  var stream = require('stream')
+  var instream = fs.createReadStream(fpath)
+  var outstream = new stream()
+  var rl = readline.createInterface(instream, outstream)
 
-  rl.setMaxListeners(0);
+  rl.setMaxListeners(0)
 
-  var presentParticiple, pastParticiple, verbConjugate, tense, present, past, isPresentParticiple, isPastParticiple, allTenses;
+  var presentParticiple,
+    pastParticiple,
+    verbConjugate,
+    tense,
+    present,
+    past,
+    isPresentParticiple,
+    isPastParticiple,
+    allTenses
 
-  rl.on('line', function(line){
-    var a = line.trim().split(",")
-    verbTenses[a[0]] = a;
-
-  });
+  rl.on('line', function(line) {
+    var a = line.trim().split(',')
+    verbTenses[a[0]] = a
+  })
 
   rl.on('close', function() {
-
     // Each verb can be lemmatised:
     // inflected morphs of the verb point
     // to its infinitive in this dictionary.
     var verbLemmas = {}
     for (infinitive in verbTenses) {
       for (tense in verbTenses[infinitive]) {
-        if (verbTenses[infinitive][tense] != "") {
-          var t = verbTenses[infinitive][tense];
-          verbLemmas[t] = infinitive;
+        if (verbTenses[infinitive][tense] != '') {
+          var t = verbTenses[infinitive][tense]
+          verbLemmas[t] = infinitive
           // verbLemmas[infinitive] = verbTenses[infinitive][tense];
         }
       }
     }
-    
 
     // Should be an obj of arrays with the key being the lemma
     // console.log(verbTenses)
@@ -97,14 +101,14 @@ module.exports = function(cb) {
     // For example:
     // give -> giving, be -> being, swim -> swimming
     presentParticiple = function(v) {
-      return verbConjugate(v, "present participle")
-    }   
+      return verbConjugate(v, 'present participle')
+    }
 
-    // Inflects the verb in the present participle.        
+    // Inflects the verb in the present participle.
     // For example:
     // give -> given, be -> been, swim -> swum
     pastParticiple = function(v) {
-      return verbConjugate(v, "past participle")
+      return verbConjugate(v, 'past participle')
     }
 
     // Inflects the verb to the given tense.
@@ -115,32 +119,30 @@ module.exports = function(cb) {
     // past participle: been,
     // negated present: I am not, you aren't, it isn't.
     verbConjugate = function(v, tense, negate) {
-      
-      tense = tense || "infinitive";
-      negate = negate || false;
+      tense = tense || 'infinitive'
+      negate = negate || false
 
-      v = verbInfinitive(v);
+      v = verbInfinitive(v)
       var i = verb_tenses_keys[tense]
-      
+
       if (negate === true) {
-        i += Object.keys(verb_tenses_keys).length;
+        i += Object.keys(verb_tenses_keys).length
       }
 
       if (v) {
-        return verbTenses[v][i];
+        return verbTenses[v][i]
       } else {
-        return ""
+        return ''
       }
-      
     }
-        
+
     // Returns the uninflected form of the verb.
     // swimming => swim, swam => swim
     verbInfinitive = function(v) {
       if (verbLemmas[v]) {
-        return verbLemmas[v];
+        return verbLemmas[v]
       } else {
-        return "";
+        return ''
       }
     }
 
@@ -148,22 +150,22 @@ module.exports = function(cb) {
     // The person can be specified with 1, 2, 3, "1st", "2nd", "3rd", "plural", "*".
     // Some verbs like be, have, must, can be negated.
     present = function(v, person, negate) {
-      person = person || "";
-      negate = negate || false;
+      person = person || ''
+      negate = negate || false
 
       // person = person.replace("pl","*").strip("stndrgural")
 
       var hash = {
-        "1" : "1st singular present",
-        "2" : "2nd singular present",
-        "3" : "3rd singular present",
-        "*" : "present plural",
+        '1': '1st singular present',
+        '2': '2nd singular present',
+        '3': '3rd singular present',
+        '*': 'present plural'
       }
 
-      if (hash[person] && verbConjugate(v, hash[person], negate) != "") {
+      if (hash[person] && verbConjugate(v, hash[person], negate) != '') {
         return verbConjugate(v, hash[person], negate)
       } else {
-        return verbConjugate(v, "infinitive", negate)  
+        return verbConjugate(v, 'infinitive', negate)
       }
     }
 
@@ -173,87 +175,85 @@ module.exports = function(cb) {
     // For example:
     // give -> gave, be -> was, swim -> swam
     past = function(v, person, negate) {
-      person = person || "";
-      negate = negate || false;
+      person = person || ''
+      negate = negate || false
 
-    //     person = str(person).replace("pl","*").strip("stndrgural")
+      //     person = str(person).replace("pl","*").strip("stndrgural")
       var hash = {
-        "1" : "1st singular present",
-        "2" : "2nd singular present",
-        "3" : "3rd singular present",
-        "*" : "present plural",
+        '1': '1st singular past',
+        '2': '2nd singular past',
+        '3': '3rd singular past',
+        '*': 'past plural'
       }
 
-      if (hash[person] && verbConjugate(v, hash[person], negate) != "") {
+      if (hash[person] && verbConjugate(v, hash[person], negate) != '') {
         return verbConjugate(v, hash[person], negate)
       } else {
-        return verbConjugate(v, "past", negate)  
+        return verbConjugate(v, 'past', negate)
       }
     }
 
-    // Returns a string from verb_tenses_keys representing the verb's tense.    
+    // Returns a string from verb_tenses_keys representing the verb's tense.
     // For example:
     // given -> "past participle"
     tense = function(v) {
-      var infinitive = verbInfinitive(v);
-      var a = verbTenses[infinitive];
-      
+      var infinitive = verbInfinitive(v)
+      var a = verbTenses[infinitive]
+
       if (a) {
         for (t in verb_tenses_keys) {
           if (a && a[verb_tenses_keys[t]] == v) {
             return t
           }
-          
-          if (a && a[verb_tenses_keys[t]+verb_tenses_keys.length] == v) {
+
+          if (a && a[verb_tenses_keys[t] + verb_tenses_keys.length] == v) {
             return t
           }
-        }        
+        }
       } else {
-        return null;
+        return null
       }
     }
 
     // Checks whether the verb is in present participle.
     isPresentParticiple = function(v) {
-      return (tense(v) == "present participle") ? true : false;
+      return tense(v) == 'present participle' ? true : false
     }
 
-    // Checks whether the verb is in past participle.    
+    // Checks whether the verb is in past participle.
     isPastParticiple = function(v) {
-      return (tense(v) == "past participle") ? true : false;
+      return tense(v) == 'past participle' ? true : false
     }
 
     // Returns all possible verb tenses.
     allTenses = function() {
-      return Object.keys(verb_tenses_keys);
+      return Object.keys(verb_tenses_keys)
     }
 
     cb({
-        presentParticiple: presentParticiple,
-        pastParticiple: pastParticiple,
-        present: present,
-        past: past,
-        tense: tense,
-        isPresentParticiple: isPresentParticiple,
-        isPastParticiple: isPastParticiple,
+      presentParticiple: presentParticiple,
+      pastParticiple: pastParticiple,
+      present: present,
+      past: past,
+      tense: tense,
+      isPresentParticiple: isPresentParticiple,
+      isPastParticiple: isPastParticiple,
 
-        allTenses:allTenses
-      });
-
-  });
-
+      allTenses: allTenses
+    })
+  })
 }
 
 // Checks whether the verb is in the given tense.
 // def isTense(v, tense, negated=False):
-        
+
 //     if tense in verb_tenses_aliases:
 //         tense = verb_tenses_aliases[tense]
 //     if verb_tense(v) == tense:
 //         return True
 //     else:
 //         return False
-        
+
 // Checks whether the verb is in the present tense.
 // def isPresent(v, person="", negated=False):
 
@@ -266,8 +266,6 @@ module.exports = function(cb) {
 //             elif "n't" in v or " not" in v:
 //                 return True
 //     return False
-    
-
 
 // Checks whether the verb is in the past tense.
 // def isPast(v, person="", negated=False):
@@ -279,6 +277,5 @@ module.exports = function(cb) {
 //                 return True
 //             elif "n't" in v or " not" in v:
 //                 return True
-    
-//     return False
 
+//     return False


### PR DESCRIPTION
Probably you just forgot to change the hash object in the past function. So I've changed it to be past tense instead of present tense ( look in the past function ).
After I'd made some test on the past tense for different subjects, I encountered this and got for verb `be` with subject 2 `is` instead of `was`.

Thanks for this nice package:)